### PR TITLE
fix a bit the array printer (\0 wrong insertion)

### DIFF
--- a/lib/o.ml
+++ b/lib/o.ml
@@ -70,6 +70,8 @@ let to_hexdigit alphabet pad off output len value =
 
 let apply_style code ~off output = Fmt.ansi_style_code output off code
 let reset_style ~off output = Fmt.ansi_style_code output off `None
+let _begin = 0b01
+let _end = 0b10
 
 let with_comments (cfg : caml) input src_off src_len output dst_off =
   let dst_off =
@@ -146,9 +148,6 @@ let deterministic_length styled (cfg : xxd) input off len =
 
 let formatter_is_styled ppf =
   match Fmt.style_renderer ppf with `None -> false | `Ansi -> true
-
-let _begin = 0b01
-let _end = 0b10
 
 let to_line cfg ppf ~seek ?(state = 0) input ~src_off ~src_len output ~dst_off =
   let styled = formatter_is_styled ppf in
@@ -233,8 +232,8 @@ let to_line cfg ppf ~seek ?(state = 0) input ~src_off ~src_len output ~dst_off =
             ; off := !off + 2
           | `Array ->
             output.![!off] <- ' '
-            ; output.![!off] <- ' '
-            ; output.![!off] <- ' '
+            ; output.![!off + 1] <- ' '
+            ; output.![!off + 2] <- ' '
             ; off := !off + 3)
       ; if cfg.with_comments then
           off := with_comments cfg input src_off src_len output !off

--- a/test/caml.t
+++ b/test/caml.t
@@ -108,7 +108,15 @@ Tests about caml outputs
   $ ocamlopt main.ml
   $ ./a.out
   Hello World!
+  $ echo "abababababababab" | hxd.caml --with-comments -k array
+  [| "\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62"    (* abababababababab *)
+   ; "\x0a" |]                                                             (* .                *)
+  $ echo -n "abababababababababababababababab" | hxd.caml --with-comments -k array
+  [| "\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62"    (* abababababababab *)
+   ; "\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62\x61\x62" |] (* abababababababab *)
   $ echo "foo & bar" | hxd.caml --with-comments -k array
   [| "\x66\x6f\x6f\x20\x26\x20\x62\x61\x72\x0a" |]                         (* foo & bar.       *)
   $ echo "foo & bar" | hxd.caml --with-comments -k array -c10
   [| "\x66\x6f\x6f\x20\x26\x20\x62\x61\x72\x0a" |] (* foo & bar. *)
+  $ echo "Hello World!"
+  Hello World!


### PR DESCRIPTION
A small fix about array printers with tests.