### PR TITLE
tests: prevent tests using yes from failing if SIGPIPE is trapped

### DIFF
--- a/test/caml.t
+++ b/test/caml.t
@@ -56,7 +56,7 @@ Tests about caml outputs
   $ ocamlopt main.ml
   $ ./a.out
   foo & bar
-  $ yes "Hello World!" | head -n 10 | hxd.caml --kind=array
+  $ yes "Hello World!" 2> /dev/null | head -n 10 | hxd.caml --kind=array
   [| "\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x0a\x48\x65\x6c"
    ; "\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x0a\x48\x65\x6c\x6c\x6f\x20"
    ; "\x57\x6f\x72\x6c\x64\x21\x0a\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72"
@@ -66,7 +66,7 @@ Tests about caml outputs
    ; "\x20\x57\x6f\x72\x6c\x64\x21\x0a\x48\x65\x6c\x6c\x6f\x20\x57\x6f"
    ; "\x72\x6c\x64\x21\x0a\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64"
    ; "\x21\x0a" |]
-  $ yes "Hello World!" | head -n100 > file
+  $ yes "Hello World!" 2> /dev/null | head -n100 > file
   $ sh -c "dd of=plain_snippet status=none bs=1k count=1; hxd.caml -s +128 > caml_snippet" < file
   $ cat >main.ml <<EOF
   > let input = 

--- a/test/simple.t
+++ b/test/simple.t
@@ -13,7 +13,7 @@ Simple tests
   $ printf 'abababababababab\0' | hxd.xxd
   00000000: 6162 6162 6162 6162 6162 6162 6162 6162  abababababababab
   00000010: 00                                       .
-  $ yes "Hello World!" | head -n 10 | hxd.xxd
+  $ yes "Hello World!" 2> /dev/null | head -n 10 | hxd.xxd
   00000000: 4865 6c6c 6f20 576f 726c 6421 0a48 656c  Hello World!.Hel
   00000010: 6c6f 2057 6f72 6c64 210a 4865 6c6c 6f20  lo World!.Hello 
   00000020: 576f 726c 6421 0a48 656c 6c6f 2057 6f72  World!.Hello Wor
@@ -40,7 +40,7 @@ Simple tests
   Hello World!
   $ cat hex_copy
   00000000: 4865 6c6c 6f20 576f 726c 6421 0a         Hello World!.
-  $ yes "Hello World!" | head -n100 > file
+  $ yes "Hello World!" 2> /dev/null | head -n100 > file
   $ sh -c "dd of=plain_snippet status=none bs=1k count=1; hxd.xxd -s +128 > hex_snippet" < file
   $ hxd.xxd -s 0x480 file > result.out
   $ diff hex_snippet result.out


### PR DESCRIPTION
Usually, yes terminates cleanly if SIGPIPE is issued, indicating that
the command piped into has been terminated. However, in some
environments (some CIs apparently, the nix build sandbox) the SIGPIPE
signal is filtered or trapped causing yes to print a warning about a
its broken stdout pipe to stderr which in turn makes the tests of hxd
fail.

This is easily fixed by redirecting stderr to /dev/null since that
warning doesn't interest us.