### PR TITLE
Fix the caml support

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.27.0
+version=0.28.1
 module-item-spacing=compact
 break-struct=natural
 break-infix=fit-or-vertical

--- a/lib/fmt.ml
+++ b/lib/fmt.ml
@@ -81,8 +81,7 @@ let ansi_style_code buffer off = function
         buffer.![off] <- ';'
         ; let off = to_decdigit buffer (succ off) b in
           buffer.![off] <- 'm'
-          ; (* Format.eprintf ">> %S.\n%!" (Bytes.sub_string buffer anchor ((off + 1) - anchor)) ; *)
-            off + 1
+          ; off + 1
   | `Style (style, (#rest as color)) ->
     let color =
       match color with

--- a/lib/hxd.mli
+++ b/lib/hxd.mli
@@ -93,9 +93,7 @@ type ('f, 'b, 's, 'e) input =
 type ('f, 'b, 's, 'e) output =
   'f -> 'b -> off:int -> len:int -> ((int, 'e) result, 's) io
 
-module Make (S : sig
-  type 'a t
-end) : sig
+module Make (S : sig type 'a t end) : sig
   type t
   type 'a s = 'a S.t
 

--- a/lib/o.ml
+++ b/lib/o.ml
@@ -247,7 +247,8 @@ let to_line cfg ppf ~seek ?(state = 0) input ~src_off ~src_len output ~dst_off =
              ; off := !off + 3)
       ; if cfg.with_comments then
           off := with_comments cfg input src_off src_len output !off
-        ; Format.fprintf ppf "%s@," (Bytes.sub_string output anchor (!off - anchor))
+        ; Format.fprintf ppf "%s@,"
+            (Bytes.sub_string output anchor (!off - anchor))
         ; output.![!off] <- '\n'
         ; !off + 1
 
@@ -316,8 +317,7 @@ let flush : type fo s e.
     -> string
     -> len:int
     -> ((int, e) result, s) io =
- fun _ send oc str ~len ->
-   send oc str ~off:0 ~len
+ fun _ send oc str ~len -> send oc str ~off:0 ~len
 
 let flush_all : type fo s e.
        s scheduler

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -24,9 +24,7 @@ module Common = struct
   external prj : 'a -> 'b = "%identity"
 end
 
-module type FUNCTOR = sig
-  type 'a t
-end
+module type FUNCTOR = sig type 'a t end
 
 module Make (T : FUNCTOR) = struct
   type 'a s = 'a T.t

--- a/test/caml.t
+++ b/test/caml.t
@@ -120,3 +120,13 @@ Tests about caml outputs
   [| "\x66\x6f\x6f\x20\x26\x20\x62\x61\x72\x0a" |] (* foo & bar. *)
   $ echo "Hello World!"
   Hello World!
+  $ cat >fix.ml <<EOF
+  > let input =
+  > EOF
+  $ echo '"Hello World!"' | hxd.caml --with-comments -k array >> fix.ml
+  $ cat >>fix.ml <<EOF
+  > let () = Array.iter print_string input
+  > EOF
+  $ ocamlopt fix.ml
+  $ ./a.out
+  "Hello World!"


### PR DESCRIPTION
- Use `ppf` when we would like to print out caml values
- Escape '"' which is does not work when we use as a caml value